### PR TITLE
Upgrade to new ExtensionInterface for GrumPHP 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,7 @@
         }
     ],
     "require": {
-        "php": "^8.1"
-    },
-    "require-dev": {
+        "php": "^8.1",
         "phpro/grumphp": "^2.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0"
+        "php": "^8.1"
     },
     "require-dev": {
-        "phpro/grumphp": "^1.0"
+        "phpro/grumphp": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/config/doctrine-task-extension.yaml
+++ b/config/doctrine-task-extension.yaml
@@ -1,0 +1,8 @@
+services:
+    JonMldr\GrumPhpDoctrineTask\DoctrineSchemaValidateTask:
+        class: \JonMldr\GrumPhpDoctrineTask\DoctrineSchemaValidateTask
+        arguments:
+            - "@process_builder"
+            - "@formatter.raw_process"
+        tags:
+            - { name: grumphp.task, task: doctrine_schema_validate }

--- a/src/DoctrineSchemaValidateTask.php
+++ b/src/DoctrineSchemaValidateTask.php
@@ -7,6 +7,7 @@ namespace JonMldr\GrumPhpDoctrineTask;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Runner\TaskResultInterface;
 use GrumPHP\Task\AbstractExternalTask;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
 use GrumPHP\Task\Context\RunContext;
@@ -30,7 +31,7 @@ class DoctrineSchemaValidateTask extends AbstractExternalTask
     /**
      * {@inheritdoc}
      */
-    public static function getConfigurableOptions(): OptionsResolver
+    public static function getConfigurableOptions(): ConfigOptionsResolver
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
@@ -44,7 +45,9 @@ class DoctrineSchemaValidateTask extends AbstractExternalTask
             ->addAllowedTypes('skip_sync', ['bool'])
             ->addAllowedTypes('triggered_by', ['array']);
 
-        return $resolver;
+        return ConfigOptionsResolver::fromClosure(
+            static fn (array $options): array => $resolver->resolve($options)
+        );
     }
 
     /**

--- a/src/ExtensionLoader.php
+++ b/src/ExtensionLoader.php
@@ -10,11 +10,10 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class ExtensionLoader implements ExtensionInterface
 {
-    public function load(ContainerBuilder $container): void
+    public function imports(): iterable
     {
-        $container->register('task.doctrine_schema_validate', DoctrineSchemaValidateTask::class)
-            ->addArgument(new Reference('process_builder'))
-            ->addArgument(new Reference('formatter.raw_process'))
-            ->addTag('grumphp.task', ['task' => 'doctrine_schema_validate']);
+        $configDir = dirname(__DIR__) . '/config';
+
+        yield $configDir . '/doctrine-task-extension.yaml';
     }
 }


### PR DESCRIPTION
The Extension interface for the new GrumPHP version 2 is changed and no longer compatible with the old style, see: https://github.com/phpro/grumphp/blob/v2.x/UPGRADE-v2.md

I also recommend to change the composer.json for the "old" version to move the requirement for grumphp from require-dev to require so that in case the old version is used it wouldn't break.

Also, I didn't change your README with the changelog, because I don't know what you want with your versioning.